### PR TITLE
Fix ArgumentException when sending long message

### DIFF
--- a/common/kcp.cs
+++ b/common/kcp.cs
@@ -323,10 +323,10 @@ public class KCP
 
         for (var i = 0; i < count; i++) {
             var size = 0;
-            if (buffer.Length > mss)
+            if (buffer.Length - offset > mss)
                 size = (int)mss;
             else
-                size = buffer.Length;
+                size = buffer.Length - offset;
 
             var seg = new Segment(size);
             Array.Copy(buffer, offset, seg.data, 0, size);


### PR DESCRIPTION
For example buffer is 1500 bytes and mss is 1376 bytes. kcp creates 2 segments with 1376 length. When KCP trying to copy from buffer starts from 1376 byte to second segment starts from 0 1376 bytes KCP trowing System.ArgumentException: length  at System.Array.Copy.