### PR TITLE
rto值计算fix

### DIFF
--- a/KCP/KCP.cs
+++ b/KCP/KCP.cs
@@ -432,6 +432,7 @@ namespace KcpProject
             else
             {
                 Int32 delta = (Int32)((UInt32)rtt - rx_srtt);
+                rx_srtt += (UInt32)(delta >> 3);
                 if (0 > delta) delta = -delta;
 
                 if (rtt < rx_srtt - rx_rttval)
@@ -439,11 +440,11 @@ namespace KcpProject
                     // if the new RTT sample is below the bottom of the range of
                     // what an RTT measurement is expected to be.
                     // give an 8x reduced weight versus its normal weighting
-                    rx_rttval += ((uint)delta - rx_rttval) >> 5;
+                    rx_rttval += (uint)((delta - rx_rttval) >> 5);
                 }
                 else
                 {
-                    rx_rttval += ((uint)delta - rx_rttval) >> 2;
+                    rx_rttval += (uint)((delta - rx_rttval) >> 2);
                 }
             }
 


### PR DESCRIPTION
rto计算出来的值 一直是最大值6000  根据kcpgo代码对比加了一行计算srtt 和rttval值计算转换修改